### PR TITLE
Removed Code CSS Block

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -1671,16 +1671,6 @@
 		padding: 0.5em 0 0.5em 1.5em;
 	}
 
-	code {
-		background: #f7f7f7;
-		border-radius: 0.35em;
-		border: solid 2px #efefef;
-		font-family: "Courier New", monospace;
-		font-size: 0.9em;
-		margin: 0 0.25em;
-		padding: 0.25em 0.65em;
-	}
-
 	pre {
 		-webkit-overflow-scrolling: touch;
 		font-family: "Courier New", monospace;


### PR DESCRIPTION
This was getting in the way of Hugo's built-in syntax highlighter.